### PR TITLE
Use latest docs link in NOTES.txt

### DIFF
--- a/NOTES.txt
+++ b/NOTES.txt
@@ -1,4 +1,4 @@
-A template for writing a Configuration (https://docs.crossplane.io/v1.14/concepts/packages).
+A template for writing a Configuration (https://docs.crossplane.io/latest/concepts/packages).
 
 To use this template:
 1. Replace the name, metadata in crossplane.yaml to reflect your Configuration.


### PR DESCRIPTION
This PR updates a missed link to point to the `latest` docs instead of a specific version, so it will stay accurate over time.